### PR TITLE
Set the run_at to document_idle so Forem instance pages remain performant

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "run_at": "document_start",
+      "run_at": "document_idle",
       "js": ["content/content.js"]
     }
   ]


### PR DESCRIPTION
Allows for Forem instances to load as fast as they normally do by only loading the browser extension once the page is idle (recommended).

Fixes #24