### PR TITLE
Revert document_idle modification

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "run_at": "document_idle",
+      "run_at": "document_start",
       "js": ["content/content.js"]
     }
   ]


### PR DESCRIPTION
#25 created an issue with the extension not loading properly. (#36)

I like the principles of that PR, but it broke the expected behavior.

## With `document_idle`

![start](https://im.ezgif.com/tmp/ezgif-1-0eb50ef62e95.gif)

## With `document_start`

![idle](https://im.ezgif.com/tmp/ezgif-1-41f83850bdc5.gif)