### PR TITLE
Add browser_specific_settings for firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,8 +7,14 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "run_at": "document_start",
-      "js": ["content/content.js"]
+      "js": ["content/content.js"],
+      "run_at": "document_start"
     }
-  ]
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "@forem",
+        "strict_min_version": "42.0"
+    }
+  }
 }


### PR DESCRIPTION
This change is required because the extension uses `storage.sync`.

More documentation here:
https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/#When_do_you_need_an_add-on_ID

I'm new to working on browser extensions, but after some digging through docs, this seems to work.

I tested this with [web-ext](https://github.com/mozilla/web-ext) (super handy!) and then installed it on both my Chrome and Firefox browsers. It seems to work as expected!

Closes #2 