### PR TITLE
Ensure left padding on edge case components

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -166,7 +166,11 @@ function loadForemHTML(forems) {
   constructedSidecarIframe.srcdoc = foremHTML;
   const newStyles = document.createElement('STYLE');
   newStyles.innerHTML =
-    '@media (max-width: 1380px){body {padding-left:60px !important} .crayons-header {left: 58px !important}} #forem-sidecar {top:0;left:0;bottom:0;height:100vh;width:60px;border:0;z-index:100000;position:fixed}';
+    `#chat {padding-left:60px !important}
+     .crayons-snackbar {left: 70px !important}
+     @media (max-width: 1380px){body {padding-left:60px !important}
+     .crayons-header {left: 58px !important}}
+     #forem-sidecar {top:0;left:0;bottom:0;height:100vh;width:60px;border:0;z-index:100000;position:fixed}`;
   document.documentElement.appendChild(newStyles);
   document.documentElement.appendChild(constructedSidecarIframe);
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The way we're currently injecting this css doesn't account for edge-to-edge views and any left "floating" content like the snackbar. This squashes those cases.