### PR TITLE
Reduce storage usage

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -44,6 +44,8 @@ function initializeForemLogic() {
           'https://www.forem.com/valid_forems.json',
         );
         const json = await response.json();
+        filterForemJson(json);
+          
         chrome.storage.sync.set({ allforems: json.forems }); // Create empty array if not initialized.
         const versionSubstring = json.meta.latestExtensionVersion.substring(0, 3);
         if (versionSubstring != '0.2') {
@@ -285,4 +287,12 @@ function arrayContainsUrl(url, myArray){
         return myArray[i];
     }
   }
+}
+
+function filterForemJson(json) {
+  // We don't need this information for the sidebar, so let's not store it.
+  json.forems.forEach(function(forem, i) {
+    delete forem.description;
+    delete forem.socialCardImage;
+  })
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As reported in https://github.com/forem/forem-browser-extension/issues/53, users are unable to add more than about 3 forems using the Forem browser extension on Safari 14. This is due to Safari 14 only allowing 10kB of storage in it's `chrome.storage.sync` area (as opposed to 102kB in Chrome and Firefox). I suspect this is due to a bug in webkit/Safari.

There are a couple of approaches we could take in the long term (outlined in Issue https://github.com/forem/forem-browser-extension/issues/54), but in the short term this allows Safari users to add more than 3 forems to their sidebar. I removed unused attributes from local storage (the Forem's description and social card image URL), which accounts for the space savings.

Previously, adding 3 forems to the sidebar in Safari used up about 10 kB of plugin storage space. After this patch, storage usage was 9 kB with 12 forems added!

## Related Tickets & Documents

fixes https://github.com/forem/forem-browser-extension/issues/53

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## [optional] What gif best describes this PR or how it makes you feel?

![ezgif com-optimize](https://user-images.githubusercontent.com/37842/105637330-9cfaf400-5e32-11eb-9272-3ba40beb625e.gif)
