### PR TITLE
Rev Safari build number to 5 because of AppStoreConnect shennanigans

### DIFF
--- a/safari/Forem for Safari.xcodeproj/project.pbxproj
+++ b/safari/Forem for Safari.xcodeproj/project.pbxproj
@@ -428,7 +428,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Forem for Safari Extension/Forem_for_Safari_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = R9SWHSQNV8;
 				INFOPLIST_FILE = "Forem for Safari Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -451,7 +451,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Forem for Safari Extension/Forem_for_Safari_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = R9SWHSQNV8;
 				INFOPLIST_FILE = "Forem for Safari Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -478,7 +478,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = R9SWHSQNV8;
 				INFOPLIST_FILE = "Forem for Safari/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -502,7 +502,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = R9SWHSQNV8;
 				INFOPLIST_FILE = "Forem for Safari/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
AppStoreConnect was being flakey, and I had to upload a new build. This PR just revs the Safari build number from 4 to 5